### PR TITLE
update: font family for all webpages #89

### DIFF
--- a/src/_includes/head.njk
+++ b/src/_includes/head.njk
@@ -4,6 +4,7 @@
 <link rel="preload" href="{{ env.baseUrl }}css/page.css" as="style">
 <link rel="icon" type="image/x-icon" href="{{ env.baseUrl }}img/logo.png">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link href="https://fonts.googleapis.com/css2?family=Black+Han+Sans&family=Hanken+Grotesk&display=swap" rel="stylesheet">
 <!-- PRELOAD CDN SCRIPTS -->
 <link rel="preconnect" href="https://unpkg.com/popper.js@1" as="script">
 <link rel="preconnect" href="https://unpkg.com/tippy.js@4" as="script">

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -19,8 +19,12 @@ html {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Black Han Sans', sans-serif;
+}
+
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: 'Hanken Grotesk', sans-serif;
   color: #111827;
   background-color: #FFFFFF;
   min-height: 100vh;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -251,6 +251,8 @@ module.exports = {
       DEFAULT: '1',
     },
     fontFamily: {
+      heading: ['"Black Han Sans"', 'sans-serif'],
+      body: ['"Hanken Grotesk"', 'sans-serif'],
       sans: [
         'ui-sans-serif',
         'system-ui',


### PR DESCRIPTION
updating font family for all webpages, issue : #89 
before: 
<img width="1489" alt="Screenshot 2025-05-26 at 11 46 30 AM" src="https://github.com/user-attachments/assets/9db2eb06-9cac-4680-8764-0057759c650d" />
after:
<img width="1488" alt="Screenshot 2025-05-26 at 11 47 46 AM" src="https://github.com/user-attachments/assets/aa10ac5c-3339-4b9e-a8da-5dbc72fa5fd0" />

